### PR TITLE
Consolidate Electron Forge configuration

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -4,16 +4,21 @@ const { FuseV1Options, FuseVersion } = require('@electron/fuses');
 module.exports = {
   packagerConfig: {
     asar: true,
+    icon: './assets/icon',
   },
   rebuildConfig: {},
   makers: [
     {
       name: '@electron-forge/maker-squirrel',
-      config: {},
+      config: {
+        name: 'breakout_prop_app',
+        authors: 'Your Name or Organization',
+        description: 'A desktop app interface for Breakout Prop',
+      },
     },
     {
       name: '@electron-forge/maker-zip',
-      platforms: ['darwin'],
+      platforms: ['win32'],
     },
     {
       name: '@electron-forge/maker-deb',

--- a/package.json
+++ b/package.json
@@ -28,34 +28,6 @@
     "electron-squirrel-startup": "^1.0.1"
   },
   "config": {
-    "forge": {
-      "packagerConfig": {
-        "icon": "./assets/icon"
-      },
-      "makers": [
-        {
-          "name": "@electron-forge/maker-squirrel",
-          "config": {
-            "name": "breakout_prop_app",
-            "authors": "Your Name or Organization",
-            "description": "A desktop app interface for Breakout Prop"
-          }
-        },
-        {
-          "name": "@electron-forge/maker-zip",
-          "platforms": [
-            "win32"
-          ]
-        },
-        {
-          "name": "@electron-forge/maker-deb",
-          "config": {}
-        },
-        {
-          "name": "@electron-forge/maker-rpm",
-          "config": {}
-        }
-      ]
-    }
+    "forge": "./forge.config.js"
   }
 }


### PR DESCRIPTION
## Summary
- point package.json at the shared forge.config.js so settings live in a single place
- carry over maker metadata and packager icon into forge.config.js alongside existing ASAR and fuse options

## Testing
- npm run make *(fails: missing external binaries dpkg, fakeroot)*

------
https://chatgpt.com/codex/tasks/task_e_68d8ccdfe9508332b57e3e9514c98806