### PR TITLE
Harden navigation security for remote app

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,22 @@
-const { app, BrowserWindow } = require('electron');
+const { app, BrowserWindow, shell, session } = require('electron');
+
+const ALLOWED_HOSTS = ['app.breakoutprop.com'];
+
+function isAllowedUrl(targetUrl) {
+  try {
+    const parsedUrl = new URL(targetUrl);
+    const { protocol, host } = parsedUrl;
+    if (protocol !== 'https:') {
+      return false;
+    }
+
+    return ALLOWED_HOSTS.some(
+      (allowedHost) => host === allowedHost || host.endsWith(`.${allowedHost}`)
+    );
+  } catch (error) {
+    return false;
+  }
+}
 
 function createWindow() {
   const win = new BrowserWindow({
@@ -7,13 +25,53 @@ function createWindow() {
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,
+      sandbox: true,
+      enableRemoteModule: false,
     },
   });
 
   win.loadURL('https://app.breakoutprop.com/');
+
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    if (isAllowedUrl(url)) {
+      return { action: 'allow' };
+    }
+
+    shell.openExternal(url);
+    return { action: 'deny' };
+  });
+
+  win.webContents.on('will-navigate', (event, url) => {
+    if (!isAllowedUrl(url)) {
+      event.preventDefault();
+      shell.openExternal(url);
+    }
+  });
 }
 
 app.whenReady().then(() => {
+  if (session.defaultSession) {
+    session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+      const responseHeaders = details.responseHeaders || {};
+      const hasContentSecurityPolicy = Object.keys(responseHeaders).some(
+        (header) => header.toLowerCase() === 'content-security-policy'
+      );
+
+      if (!hasContentSecurityPolicy) {
+        responseHeaders['Content-Security-Policy'] = [
+          "default-src 'self' https://app.breakoutprop.com https://*.breakoutprop.com data: blob:; " +
+            "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://app.breakoutprop.com https://*.breakoutprop.com; " +
+            "connect-src 'self' https://app.breakoutprop.com https://*.breakoutprop.com wss://*.breakoutprop.com; " +
+            "img-src 'self' data: https://app.breakoutprop.com https://*.breakoutprop.com; " +
+            "style-src 'self' 'unsafe-inline' https://app.breakoutprop.com https://*.breakoutprop.com; " +
+            "frame-ancestors 'self';",
+        ];
+      }
+
+      callback({ responseHeaders });
+    });
+  }
+
   createWindow();
 
   app.on('activate', () => {


### PR DESCRIPTION
## Summary
- import additional Electron modules and tighten BrowserWindow sandbox settings
- restrict in-app navigation to known Breakout Prop origins and open external URLs in the system browser
- apply a fallback content security policy for remote responses that do not provide one

## Testing
- not run (requires GUI environment)


------
https://chatgpt.com/codex/tasks/task_e_68d8ccf5410c8332b9b9aeb0ef7bd008