### PR TITLE
Harden window navigation handling

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -1,0 +1,3 @@
+'use strict';
+
+// Preload placeholder to maintain an isolated, sandboxed renderer environment.


### PR DESCRIPTION
## Summary
- add a sandboxed preload script to back the BrowserWindow security settings
- restrict window opening and navigation to the Breakout Prop origin while routing externals through the OS browser

## Testing
- npm run lint *(fails: ESLint configuration missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d8ce54f5808332abbfa5a7a9bbfe4e