### PR TITLE
Guard external navigation against unsafe protocols

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "generate:icons": "node scripts/generate-icons.js",
     "prestart": "npm run generate:icons",
 
-    "lint": "eslint .",
-    "test": "npm run lint",
+    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint .",
+    "test": "npm run lint && node --test",
     "start": "electron-forge start",
     "prepackage": "npm run generate:icons",
     "package": "electron-forge package",

--- a/test/openExternalIfSafe.test.js
+++ b/test/openExternalIfSafe.test.js
@@ -1,0 +1,54 @@
+process.env.SKIP_MAIN_BOOTSTRAP = 'true';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { openExternalIfSafe } = require('../main.js');
+
+test('allows vetted protocols to open externally', () => {
+  let openedUrl = null;
+  const openExternalStub = (url) => {
+    openedUrl = url;
+  };
+
+  const result = openExternalIfSafe('https://example.com/path', openExternalStub);
+
+  assert.equal(result, true);
+  assert.equal(openedUrl, 'https://example.com/path');
+});
+
+test('rejects URLs with disallowed protocols', () => {
+  let opened = false;
+  const openExternalStub = () => {
+    opened = true;
+  };
+
+  const disallowed = [
+    'file:///etc/passwd',
+    'javascript:alert(1)',
+    'custom-scheme://data',
+  ];
+
+  for (const url of disallowed) {
+    opened = false;
+    const result = openExternalIfSafe(url, openExternalStub);
+    assert.equal(result, false, `expected ${url} to be rejected`);
+    assert.equal(opened, false, `expected ${url} not to be opened`);
+  }
+});
+
+test('rejects malformed URLs and non-string values', () => {
+  let opened = false;
+  const openExternalStub = () => {
+    opened = true;
+  };
+
+  const inputs = ['not a url', '/relative/path', null, undefined, 42];
+
+  for (const input of inputs) {
+    opened = false;
+    const result = openExternalIfSafe(input, openExternalStub);
+    assert.equal(result, false, `expected ${String(input)} to be rejected`);
+    assert.equal(opened, false, `expected ${String(input)} not to be opened`);
+  }
+});


### PR DESCRIPTION
## Summary
- add an `openExternalIfSafe` helper to constrain `shell.openExternal` to vetted protocols and reuse it in navigation handlers
- gate the Electron bootstrap behind an environment flag so the helper can be imported for testing
- add unit tests for the helper and update npm scripts to run linting and the new tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8cf6019508332b64a3a7b9e9eb8b5