### PR TITLE
Harden external navigation helper

### DIFF
--- a/main.js
+++ b/main.js
@@ -5,15 +5,17 @@ const allowedOrigin = 'https://app.breakoutprop.com';
 const allowedProtocols = new Set(['http:', 'https:']);
 
 function openExternalIfSafe(targetUrl, openExternal = shell.openExternal) {
-  if (typeof targetUrl !== 'string') {
-    return false;
-  }
-
   let parsed;
 
-  try {
-    parsed = new URL(targetUrl);
-  } catch {
+  if (targetUrl instanceof URL) {
+    parsed = targetUrl;
+  } else if (typeof targetUrl === 'string') {
+    try {
+      parsed = new URL(targetUrl);
+    } catch {
+      return false;
+    }
+  } else {
     return false;
   }
 
@@ -21,7 +23,7 @@ function openExternalIfSafe(targetUrl, openExternal = shell.openExternal) {
     return false;
   }
 
-  openExternal(targetUrl);
+  openExternal(parsed.toString());
   return true;
 }
 

--- a/test/openExternalIfSafe.test.js
+++ b/test/openExternalIfSafe.test.js
@@ -11,10 +11,17 @@ test('allows vetted protocols to open externally', () => {
     openedUrl = url;
   };
 
-  const result = openExternalIfSafe('https://example.com/path', openExternalStub);
+  const stringResult = openExternalIfSafe('https://example.com/path', openExternalStub);
 
-  assert.equal(result, true);
+  assert.equal(stringResult, true);
   assert.equal(openedUrl, 'https://example.com/path');
+
+  openedUrl = null;
+  const urlObject = new URL('https://example.com/other');
+  const objectResult = openExternalIfSafe(urlObject, openExternalStub);
+
+  assert.equal(objectResult, true);
+  assert.equal(openedUrl, 'https://example.com/other');
 });
 
 test('rejects URLs with disallowed protocols', () => {
@@ -27,6 +34,7 @@ test('rejects URLs with disallowed protocols', () => {
     'file:///etc/passwd',
     'javascript:alert(1)',
     'custom-scheme://data',
+    'data:text/plain;base64,Zm9v',
   ];
 
   for (const url of disallowed) {


### PR DESCRIPTION
## Summary
- harden `openExternalIfSafe` by supporting `URL` instances and reusing parsed output for safety
- extend unit coverage to verify additional disallowed schemes and URL-object handling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8d0cb1de48332b8e4e195e49e7c05