### PR TITLE
Harden injected CSP

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,46 @@
+const crypto = require('crypto');
 const path = require('path');
 const { app, BrowserWindow, shell, session } = require('electron');
+
+// Network captures of https://app.breakoutprop.com/ (via Playwright) show the
+// UI pulling first-party assets plus Cloudflare's analytics beacon. Keep these
+// allow-lists in sync with that remote footprint so the nonce-based CSP stays
+// permissive only where the app genuinely needs it.
+const breakoutOrigins = [
+  'https://app.breakoutprop.com',
+  'https://*.breakoutprop.com',
+];
+const cspScriptOrigins = [
+  ...breakoutOrigins,
+  // Cloudflare Radar beacon script used by the hosted experience.
+  'https://performance.radar.cloudflare.com',
+];
+const cspStyleOrigins = breakoutOrigins;
+const cspConnectOrigins = [
+  ...breakoutOrigins,
+  'wss://*.breakoutprop.com',
+];
+
+function buildContentSecurityPolicy() {
+  const nonce = crypto.randomBytes(16).toString('base64');
+  const directives = [
+    "default-src 'self';",
+    "base-uri 'self';",
+    // The BreakoutProp bundle does not need eval and should only execute scripts
+    // with a matching nonce from the allow-listed origins recorded above.
+    `script-src 'self' 'nonce-${nonce}' ${cspScriptOrigins.join(' ')};`,
+    `style-src 'self' 'nonce-${nonce}' ${cspStyleOrigins.join(' ')};`,
+    `img-src 'self' data: blob: ${breakoutOrigins.join(' ')};`,
+    `connect-src 'self' ${cspConnectOrigins.join(' ')};`,
+    `font-src 'self' data: ${breakoutOrigins.join(' ')};`,
+    `frame-src 'self' ${breakoutOrigins.join(' ')};`,
+    "frame-ancestors 'self';",
+    `form-action 'self' ${breakoutOrigins.join(' ')};`,
+    "object-src 'none';",
+  ];
+
+  return directives.join(' ');
+}
 
 const allowedOrigin = 'https://app.breakoutprop.com';
 const allowedProtocols = new Set(['http:', 'https:']);
@@ -81,14 +122,7 @@ function bootstrap() {
         );
 
         if (!hasContentSecurityPolicy) {
-          responseHeaders['Content-Security-Policy'] = [
-            "default-src 'self' https://app.breakoutprop.com https://*.breakoutprop.com data: blob:; " +
-              "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://app.breakoutprop.com https://*.breakoutprop.com; " +
-              "connect-src 'self' https://app.breakoutprop.com https://*.breakoutprop.com wss://*.breakoutprop.com; " +
-              "img-src 'self' data: https://app.breakoutprop.com https://*.breakoutprop.com; " +
-              "style-src 'self' 'unsafe-inline' https://app.breakoutprop.com https://*.breakoutprop.com; " +
-              "frame-ancestors 'self';",
-          ];
+          responseHeaders['Content-Security-Policy'] = [buildContentSecurityPolicy()];
         }
 
         callback({ responseHeaders });


### PR DESCRIPTION
## Summary
- generate nonce-based content-security-policy headers when the remote BreakoutProp pages do not set their own policy
- allow only the observed script, style, and network origins needed by the hosted app while documenting the rationale in code comments
- remove the unsafe inline/eval directives from the fallback CSP so the packaged app runs with a stricter renderer sandbox

## Testing
- npm run lint
- npm run package *(fails: electron-forge prunes devDependencies and cannot find eslint during packaging)*

------
https://chatgpt.com/codex/tasks/task_e_68d8d0cc41b08332b6fb88e9592ffa23