### PR TITLE
Add unit test script to npm workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,13 @@ The app does not require custom environment variables or bundled secrets. Users 
 Contributions are welcome. Before submitting changes:
 
 1. Ensure dependencies are installed (`npm install`).
-2. Run the lint suite (wired to `npm test`) to enforce project standards.
+2. Run the automated checks. `npm test` now executes linting, formatting, unit tests, and the Playwright integration suite in the same order used in CI.
    ```bash
    npm test
    ```
-   or
+   To run only the Node.js unit tests, use the dedicated command:
    ```bash
-   npm run lint
+   npm run test:unit
    ```
 3. Verify the app still runs (`npm start`) and, if applicable, that packaged artifacts build successfully (`npm run make`).
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "prestart": "npm run generate:icons",
     "lint": "eslint .",
     "format": "prettier --check .",
-    "test": "npm run lint && npm run format && npm run test:integration",
+    "test:unit": "node --test test",
+    "test": "npm run lint && npm run format && npm run test:unit && npm run test:integration",
     "test:integration": "node scripts/run-playwright.js",
 
     "start": "electron-forge start",


### PR DESCRIPTION
## Summary
- add a dedicated npm script to run the Node.js unit tests
- have the default test pipeline run linting, formatting, unit, and integration suites
- document the updated testing workflow in the contributing guide

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d8d7d969808332af9ad3ad8644c630