### PR TITLE
Update README packaging guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ npm run package
 npm run make
 ```
 
-Refer to `forge.config.js` for maker configuration and add or adjust makers as needed for your distribution targets.
+Refer to the Forge configuration embedded in `package.json` (`package.json → config.forge`) for maker and plugin settings. Within that JSON block you can add, remove, or adjust makers and plugins to match the installers and packaging tweaks your release process requires.
 
 ## Updating an Existing Installation
 


### PR DESCRIPTION
## Summary
- update packaging documentation to point to the Forge settings inside package.json
- clarify that makers and plugins can be adjusted within the config.forge block

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8d7dcae708332aa0c988aa6cd808d