### PR TITLE
Restrict external URL handling to HTTPS only

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The project does not currently ship an auto-updater; distribute new installers g
 The Electron shell hosts the remote BreakoutProp web application at `https://app.breakoutprop.com` and applies the following hardening measures (see `main.js`):
 
 - **Renderer isolation** – `nodeIntegration` is disabled, `contextIsolation` is enabled, and the renderer runs in a sandboxed environment with a minimal preload script to prevent access to Node.js APIs from web content.
-- **Navigation restrictions** – window creation and in-app navigation are limited to the trusted BreakoutProp origin; external links open in the system browser instead of the Electron window.
+- **Navigation restrictions** – window creation and in-app navigation are limited to the trusted BreakoutProp origin; external links open in the system browser instead of the Electron window. Only HTTPS links are permitted to launch externally, preventing downgrades to insecure handlers.
 - **Content Security Policy enforcement** – responses without a CSP header receive a restrictive default policy covering scripts, styles, images, WebSocket connections, and frame ancestors.
 - **Remote content** – no local HTML is served. The hosted BreakoutProp application continues to handle authentication; no additional credentials or API keys are stored in the desktop shell.
 

--- a/main.js
+++ b/main.js
@@ -56,7 +56,10 @@ function ensureContentSecurityPolicy(details, callback) {
 }
 
 const allowedOrigin = 'https://app.breakoutprop.com';
-const allowedProtocols = new Set(['http:', 'https:']);
+// Only allow encrypted schemes we explicitly trust when delegating to the
+// system browser. Tightening this list avoids leaking sensitive URLs to
+// handlers that do not provide transport security.
+const allowedProtocols = new Set(['https:']);
 let startUrl = allowedOrigin;
 
 function openExternalIfSafe(targetUrl, openExternal = shell.openExternal) {

--- a/test/openExternalIfSafe.test.js
+++ b/test/openExternalIfSafe.test.js
@@ -31,6 +31,7 @@ test('rejects URLs with disallowed protocols', () => {
   };
 
   const disallowed = [
+    'http://example.com',
     'file:///etc/passwd',
     'javascript:alert(1)',
     'custom-scheme://data',


### PR DESCRIPTION
## Summary
- tighten the allowed protocol list to HTTPS when delegating to the system browser
- update the safety tests to verify that HTTP and other untrusted schemes are rejected
- document the external navigation restrictions in the README

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d8dd10586083328470af321187ba4d