### PR TITLE
Add unit tests for CSP header injection and bootstrap configuration

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,6 +1,8 @@
 const crypto = require('crypto');
 const path = require('path');
-const { app, BrowserWindow, shell, session } = require('electron');
+const electron = require('electron');
+
+let { app, BrowserWindow, shell, session } = electron;
 
 // Network captures of https://app.breakoutprop.com/ (via Playwright) show the
 // UI pulling first-party assets plus Cloudflare's analytics beacon. Keep these
@@ -151,4 +153,19 @@ if (process.env.SKIP_MAIN_BOOTSTRAP !== 'true') {
   bootstrap();
 }
 
-module.exports = { openExternalIfSafe, bootstrap };
+function __setElectronForTesting(overrides) {
+  ({ app, BrowserWindow, shell, session } = overrides);
+}
+
+function __resetForTesting() {
+  ({ app, BrowserWindow, shell, session } = electron);
+  startUrl = allowedOrigin;
+}
+
+module.exports = {
+  openExternalIfSafe,
+  ensureContentSecurityPolicy,
+  bootstrap,
+  __setElectronForTesting,
+  __resetForTesting,
+};

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -1,0 +1,146 @@
+process.env.SKIP_MAIN_BOOTSTRAP = 'true';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  bootstrap,
+  ensureContentSecurityPolicy,
+  __setElectronForTesting,
+  __resetForTesting,
+} = require('../main.js');
+
+function createElectronDouble() {
+  const onHeadersReceivedHandlers = [];
+  const openExternalCalls = [];
+
+  class BrowserWindowStub {
+    constructor() {
+      this.loadCalls = [];
+      this.webContentsHandlers = {};
+      BrowserWindowStub.instances.push(this);
+      this.webContents = {
+        setWindowOpenHandler: (handler) => {
+          this.windowOpenHandler = handler;
+        },
+        on: (event, handler) => {
+          this.webContentsHandlers[event] = handler;
+        },
+      };
+    }
+
+    loadURL(url) {
+      this.loadCalls.push(url);
+    }
+
+    static getAllWindows() {
+      return BrowserWindowStub.instances;
+    }
+  }
+
+  BrowserWindowStub.instances = [];
+
+  const sessionStub = {
+    defaultSession: {
+      webRequest: {
+        onHeadersReceived: (handler) => {
+          onHeadersReceivedHandlers.push(handler);
+        },
+      },
+    },
+  };
+
+  const appStub = {
+    handlers: {},
+    whenReady: () => Promise.resolve(),
+    on(event, handler) {
+      this.handlers[event] = handler;
+    },
+    quitCalled: false,
+    quit() {
+      this.quitCalled = true;
+    },
+  };
+
+  const shellStub = {
+    openExternal: (url) => {
+      openExternalCalls.push(url);
+    },
+  };
+
+  return {
+    bindings: {
+      app: appStub,
+      BrowserWindow: BrowserWindowStub,
+      shell: shellStub,
+      session: sessionStub,
+    },
+    BrowserWindowStub,
+    onHeadersReceivedHandlers,
+    openExternalCalls,
+  };
+}
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+test(
+  'bootstrap registers the CSP listener and loads the default start URL',
+  { concurrency: false },
+  async () => {
+    const double = createElectronDouble();
+    __setElectronForTesting(double.bindings);
+
+    bootstrap();
+    await flushPromises();
+
+    assert.equal(double.onHeadersReceivedHandlers.length, 1);
+    assert.strictEqual(
+      double.onHeadersReceivedHandlers[0],
+      ensureContentSecurityPolicy,
+    );
+
+    assert.equal(double.BrowserWindowStub.instances.length, 1);
+    const [createdWindow] = double.BrowserWindowStub.instances;
+    assert.deepEqual(createdWindow.loadCalls, ['https://app.breakoutprop.com']);
+
+    __resetForTesting();
+  },
+);
+
+test(
+  'bootstrap honors ELECTRON_START_URL while preserving allowedOrigin behavior',
+  { concurrency: false },
+  async () => {
+    const double = createElectronDouble();
+    __setElectronForTesting(double.bindings);
+
+    process.env.ELECTRON_START_URL = 'http://localhost:3000';
+
+    bootstrap();
+    await flushPromises();
+
+    const [createdWindow] = double.BrowserWindowStub.instances;
+    assert.deepEqual(createdWindow.loadCalls, ['http://localhost:3000']);
+
+    assert.ok(
+      createdWindow.windowOpenHandler,
+      'expected window open handler to be registered',
+    );
+
+    const allowResult = createdWindow.windowOpenHandler({
+      url: 'https://app.breakoutprop.com/path',
+    });
+    assert.deepEqual(allowResult, { action: 'allow' });
+
+    const denyResult = createdWindow.windowOpenHandler({
+      url: 'http://localhost:3000/other',
+    });
+    assert.deepEqual(denyResult, { action: 'deny' });
+    assert.deepEqual(double.openExternalCalls, ['http://localhost:3000/other']);
+    delete process.env.ELECTRON_START_URL;
+    __resetForTesting();
+  },
+);

--- a/test/ensureContentSecurityPolicy.test.js
+++ b/test/ensureContentSecurityPolicy.test.js
@@ -1,0 +1,43 @@
+process.env.SKIP_MAIN_BOOTSTRAP = 'true';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { ensureContentSecurityPolicy } = require('../main.js');
+
+function captureResult(fn) {
+  return new Promise((resolve) => {
+    fn((result) => resolve(result));
+  });
+}
+
+test('ensureContentSecurityPolicy injects a nonce-based header when missing', async () => {
+  const details = { responseHeaders: {} };
+
+  const result = await captureResult((callback) =>
+    ensureContentSecurityPolicy(details, callback),
+  );
+
+  assert.ok(result.responseHeaders['Content-Security-Policy']);
+  const [policy] = result.responseHeaders['Content-Security-Policy'];
+
+  assert.match(policy, /script-src 'self' 'nonce-[^']+' https:\/\/app\.breakoutprop\.com/);
+  assert.match(policy, /style-src 'self' 'nonce-[^']+' https:\/\/app\.breakoutprop\.com/);
+});
+
+test('ensureContentSecurityPolicy preserves existing headers', async () => {
+  const originalHeaders = {
+    'content-security-policy': ["default-src 'self'"],
+    'x-custom-header': ['value'],
+  };
+
+  const details = { responseHeaders: originalHeaders };
+
+  const result = await captureResult((callback) =>
+    ensureContentSecurityPolicy(details, callback),
+  );
+
+  assert.strictEqual(result.responseHeaders, originalHeaders);
+  assert.deepEqual(result.responseHeaders['content-security-policy'], ["default-src 'self'"]);
+  assert.deepEqual(result.responseHeaders['x-custom-header'], ['value']);
+});


### PR DESCRIPTION
## Summary
- expose testing hooks around the Electron bindings so the bootstrap logic can be verified in isolation
- add unit tests that exercise ensureContentSecurityPolicy when headers are missing or already present
- add bootstrap tests that assert the CSP listener is registered and start URL/allowed origin behavior stays intact

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d8dd119110833294f246bc9abaf9df