### PR TITLE
Restrict external navigation to HTTPS

### DIFF
--- a/main.js
+++ b/main.js
@@ -59,7 +59,7 @@ function ensureContentSecurityPolicy(details, callback) {
 
 const defaultAllowedOrigin = 'https://app.breakoutprop.com';
 let allowedOrigin = defaultAllowedOrigin;
-const allowedProtocols = new Set(['http:', 'https:']);
+const allowedProtocols = new Set(['https:']);
 let startUrl = defaultAllowedOrigin;
 
 
@@ -82,7 +82,13 @@ function openExternalIfSafe(targetUrl, openExternal = shell.openExternal) {
     return false;
   }
 
-  openExternal(parsed.toString());
+  const normalized = parsed.toString();
+
+  if (!normalized.startsWith('https://')) {
+    return false;
+  }
+
+  openExternal(normalized);
   return true;
 }
 
@@ -137,7 +143,11 @@ function bootstrap() {
     if (isHttp) {
       try {
         const parsedStart = new URL(startUrl);
-        allowedOrigin = parsedStart.origin;
+        if (parsedStart.protocol === 'https:') {
+          allowedOrigin = parsedStart.origin;
+        } else {
+          allowedOrigin = defaultAllowedOrigin;
+        }
       } catch {
         allowedOrigin = defaultAllowedOrigin;
         startUrl = defaultAllowedOrigin;

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -139,7 +139,7 @@ test(
       url: 'http://localhost:3000/other',
     });
     assert.deepEqual(denyResult, { action: 'deny' });
-    assert.deepEqual(double.openExternalCalls, ['http://localhost:3000/other']);
+    assert.deepEqual(double.openExternalCalls, []);
     delete process.env.ELECTRON_START_URL;
     __resetForTesting();
   },

--- a/test/openExternalIfSafe.test.js
+++ b/test/openExternalIfSafe.test.js
@@ -5,7 +5,7 @@ const assert = require('node:assert/strict');
 
 const { openExternalIfSafe } = require('../main.js');
 
-test('allows vetted protocols to open externally', () => {
+test('allows https URLs to open externally', () => {
   let openedUrl = null;
   const openExternalStub = (url) => {
     openedUrl = url;
@@ -22,6 +22,12 @@ test('allows vetted protocols to open externally', () => {
 
   assert.equal(objectResult, true);
   assert.equal(openedUrl, 'https://example.com/other');
+
+  openedUrl = null;
+  const uppercaseResult = openExternalIfSafe('HTTPS://EXAMPLE.COM/UPPER', openExternalStub);
+
+  assert.equal(uppercaseResult, true);
+  assert.equal(openedUrl, 'https://example.com/UPPER');
 });
 
 test('rejects URLs with disallowed protocols', () => {


### PR DESCRIPTION
## Summary
- restrict `openExternalIfSafe` to only launch HTTPS targets and normalize the outgoing URL
- avoid downgrading the allowed in-app origin when a local HTTP start URL is provided
- extend unit coverage to exercise the tightened HTTPS-only handling and updated bootstrap expectations

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d8e580cf50833293c5975428f653e8