### PR TITLE
Tighten external URL handling tests

### DIFF
--- a/main.js
+++ b/main.js
@@ -59,7 +59,7 @@ function ensureContentSecurityPolicy(details, callback) {
 
 const defaultAllowedOrigin = 'https://app.breakoutprop.com';
 let allowedOrigins = new Set([defaultAllowedOrigin]);
-const allowedProtocols = new Set(['http:', 'https:']);
+const allowedProtocols = new Set(['https:']);
 
 let startUrl = defaultAllowedOrigin;
 

--- a/test/openExternalIfSafe.test.js
+++ b/test/openExternalIfSafe.test.js
@@ -29,8 +29,8 @@ test('allows https URLs to open externally', () => {
   openedUrl = null;
   const httpResult = openExternalIfSafe('http://example.com/basic', openExternalStub);
 
-  assert.equal(httpResult, true);
-  assert.equal(openedUrl, 'http://example.com/basic');
+  assert.equal(httpResult, false);
+  assert.equal(openedUrl, null);
 
 });
 


### PR DESCRIPTION
## Summary
- update the HTTP branch of the openExternalIfSafe unit test to expect rejection and no shell invocation
- restrict the allowed protocol list in main.js to https to align with the secondary guard

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d8e99ed214833283956681682e5a0f