### PR TITLE
Document ELECTRON_START_URL override requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ npm start
 
 `npm start` runs `electron-forge start`, generates icons through the `prestart` hook, and opens the BreakoutProp web terminal within the Electron shell.
 
+### Overriding the start URL
+
+During development you can point the shell at a different origin by setting the `ELECTRON_START_URL` environment variable. The value must be a full `http://`, `https://`, or `file://` URL so the app can parse and validate it. For example:
+
+```bash
+ELECTRON_START_URL=http://localhost:3000 npm start
+```
+
+If the override is missing or fails validation (for example, because it is not a parseable `http(s)` or `file` URL), the shell falls back to the production BreakoutProp URL to avoid loading an unexpected destination.
+
 ## Packaging and Distribution
 
 Electron Forge can generate distributable artifacts through the included `make` targets. Icons are generated automatically before each build step.


### PR DESCRIPTION
## Summary
- add README guidance for using the ELECTRON_START_URL override during development
- explain the requirement for a full http(s)/file URL and document the fallback to the production start URL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8e9a0cda083329cd152ad06dc7eba