### PR TITLE
Handle invalid ELECTRON_START_URL values

### DIFF
--- a/main.js
+++ b/main.js
@@ -143,7 +143,22 @@ function createWindow() {
 
 function bootstrap() {
   resetAllowedOrigins();
-  startUrl = process.env.ELECTRON_START_URL || defaultAllowedOrigin;
+  const providedStartUrl = process.env.ELECTRON_START_URL;
+  startUrl = providedStartUrl || defaultAllowedOrigin;
+
+  if (typeof providedStartUrl === 'string') {
+    const hasSupportedProtocol =
+      providedStartUrl.startsWith('http://') ||
+      providedStartUrl.startsWith('https://') ||
+      providedStartUrl.startsWith('file://');
+
+    if (!hasSupportedProtocol) {
+      console.warn(
+        `Ignoring unsupported ELECTRON_START_URL value "${providedStartUrl}". Falling back to ${defaultAllowedOrigin}.`,
+      );
+      startUrl = defaultAllowedOrigin;
+    }
+  }
 
   if (typeof startUrl === 'string') {
     const isHttp = startUrl.startsWith('http://') || startUrl.startsWith('https://');


### PR DESCRIPTION
## Summary
- guard bootstrap against unsupported ELECTRON_START_URL values by warning and falling back to the production origin
- extend the bootstrap unit tests to cover the invalid start URL fallback behaviour

## Testing
- node --test test/bootstrap.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d8e99fd7b88332aab0cde1df6dc68e