### PR TITLE
Add static marketing site and configure Vercel build

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "prepackage": "npm run generate:icons",
     "package": "electron-forge package",
     "premake": "npm run generate:icons",
-    "make": "electron-forge make"
+    "make": "electron-forge make",
+    "build:web": "node scripts/build-web.js"
   },
   "keywords": [],
   "devDependencies": {

--- a/scripts/build-web.js
+++ b/scripts/build-web.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+
+const projectRoot = path.join(__dirname, '..');
+const sourceDir = path.join(projectRoot, 'web');
+const outputDir = path.join(projectRoot, 'out');
+
+function copyRecursive(src, dest) {
+  const stats = fs.statSync(src);
+
+  if (stats.isDirectory()) {
+    fs.mkdirSync(dest, { recursive: true });
+    for (const entry of fs.readdirSync(src)) {
+      copyRecursive(path.join(src, entry), path.join(dest, entry));
+    }
+    return;
+  }
+
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.copyFileSync(src, dest);
+}
+
+if (!fs.existsSync(sourceDir)) {
+  throw new Error(`Expected static assets under "${sourceDir}" but the directory does not exist.`);
+}
+
+fs.rmSync(outputDir, { recursive: true, force: true });
+fs.mkdirSync(outputDir, { recursive: true });
+
+copyRecursive(sourceDir, outputDir);
+
+console.log(`Static web assets copied to ${outputDir}`);

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "buildCommand": "npm run build:web",
+  "outputDirectory": "out",
+  "framework": null
+}

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>BreakoutProp Terminal</title>
+    <link rel="stylesheet" href="./styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <header class="hero">
+      <div class="hero__content">
+        <h1>BreakoutProp Terminal</h1>
+        <p>
+          Launch the BreakoutProp trading experience in a hardened desktop
+          shell, purpose-built for focused execution and safe navigation.
+        </p>
+        <div class="hero__actions">
+          <a class="btn btn--primary" href="https://github.com/kdkiss/breakoutpropterminal/releases"
+            >Download installers</a
+          >
+          <a class="btn" href="#features">Explore the features</a>
+        </div>
+      </div>
+      <div class="hero__artwork" aria-hidden="true">
+        <div class="hero__orb"></div>
+      </div>
+    </header>
+
+    <main>
+      <section id="features" class="section section--features">
+        <h2>Why ship a dedicated terminal?</h2>
+        <div class="grid">
+          <article class="card">
+            <h3>Secure defaults</h3>
+            <p>
+              We isolate renderer processes, apply restrictive navigation
+              policies, and inject a modern content security policy before
+              remote pages load.
+            </p>
+          </article>
+          <article class="card">
+            <h3>First-party experience</h3>
+            <p>
+              The terminal wraps the official BreakoutProp interface, so users
+              authenticate and trade against the same endpoints they already
+              trust in the browser.
+            </p>
+          </article>
+          <article class="card">
+            <h3>Cross-platform delivery</h3>
+            <p>
+              Build installers with Electron Forge for Windows, macOS, or Linux
+              without rewriting your web application.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section class="section section--callout">
+        <div class="callout">
+          <h2>Prefer the browser?</h2>
+          <p>
+            You can still access the BreakoutProp terminal online. Launch the
+            hosted experience directly in your browser if you do not need the
+            native shell.
+          </p>
+          <a class="btn btn--ghost" href="https://app.breakoutprop.com" target="_blank" rel="noopener"
+            >Open web terminal</a
+          >
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <p>
+        Built with Electron Forge. Inspect the source code or contribute on
+        <a href="https://github.com/kdkiss/breakoutpropterminal" target="_blank" rel="noopener"
+          >GitHub</a
+        >.
+      </p>
+    </footer>
+
+    <script src="./main.js" type="module"></script>
+  </body>
+</html>

--- a/web/main.js
+++ b/web/main.js
@@ -1,0 +1,19 @@
+const installButtons = document.querySelectorAll('a[href*="releases"]');
+
+installButtons.forEach((button) => {
+  button.addEventListener('click', () => {
+    if (window.plausible) {
+      window.plausible('download-clicked');
+    }
+  });
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+  const yearSpan = document.createElement('span');
+  yearSpan.textContent = ` © ${new Date().getFullYear()}`;
+  const footer = document.querySelector('.footer p');
+
+  if (footer) {
+    footer.appendChild(yearSpan);
+  }
+});

--- a/web/styles.css
+++ b/web/styles.css
@@ -1,0 +1,174 @@
+:root {
+  color-scheme: dark;
+  --bg: #07070d;
+  --bg-elevated: #111120;
+  --accent: #5c7cfa;
+  --accent-soft: rgba(92, 124, 250, 0.18);
+  --text: #f5f7ff;
+  --text-muted: #c0c6e7;
+  --border: rgba(255, 255, 255, 0.08);
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top right, rgba(92, 124, 250, 0.25), transparent 45%),
+    var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.hero {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: center;
+  padding: 4rem clamp(1.5rem, 5vw, 4rem) 3rem;
+}
+
+.hero__content h1 {
+  font-size: clamp(2.5rem, 5vw, 3.75rem);
+  margin: 0 0 1rem;
+}
+
+.hero__content p {
+  font-size: 1.1rem;
+  line-height: 1.6;
+  margin: 0 0 2rem;
+  color: var(--text-muted);
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.btn {
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 0.85rem 1.75rem;
+  font-weight: 600;
+  text-decoration: none;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.04);
+  transition: transform 180ms ease, box-shadow 180ms ease, background 180ms ease,
+    border-color 180ms ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(17, 17, 32, 0.45);
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+.btn--primary {
+  background: linear-gradient(135deg, #5c7cfa, #9f87ff);
+  box-shadow: 0 12px 28px rgba(92, 124, 250, 0.4);
+}
+
+.btn--ghost {
+  background: transparent;
+  border-color: rgba(92, 124, 250, 0.35);
+}
+
+.hero__artwork {
+  position: relative;
+  min-height: 240px;
+}
+
+.hero__orb {
+  position: absolute;
+  inset: 0;
+  border-radius: 32px;
+  background: linear-gradient(145deg, rgba(92, 124, 250, 0.85), rgba(82, 189, 255, 0.65));
+  filter: drop-shadow(0 40px 60px rgba(92, 124, 250, 0.35));
+  opacity: 0.9;
+  transform: perspective(800px) rotateX(12deg) rotateY(-18deg);
+}
+
+.section {
+  padding: 3rem clamp(1.5rem, 6vw, 5rem);
+}
+
+.section--features h2 {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 1.75rem;
+  box-shadow: 0 18px 40px rgba(6, 6, 14, 0.35);
+}
+
+.card h3 {
+  margin-top: 0;
+}
+
+.card p {
+  margin-bottom: 0;
+  line-height: 1.6;
+  color: var(--text-muted);
+}
+
+.section--callout {
+  display: flex;
+  justify-content: center;
+}
+
+.callout {
+  max-width: 720px;
+  width: 100%;
+  background: var(--bg-elevated);
+  border-radius: 28px;
+  border: 1px solid var(--accent-soft);
+  padding: clamp(2rem, 5vw, 3rem);
+  text-align: center;
+  box-shadow: 0 24px 48px rgba(6, 6, 14, 0.45);
+}
+
+.callout p {
+  color: var(--text-muted);
+  line-height: 1.7;
+}
+
+.footer {
+  margin-top: auto;
+  padding: 2.5rem 1.5rem 3rem;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.footer a {
+  color: var(--text);
+}
+
+@media (max-width: 720px) {
+  .hero {
+    padding-top: 3rem;
+  }
+
+  .hero__artwork {
+    min-height: 180px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a lightweight static marketing page under `web/` highlighting the desktop terminal and linking to downloads
- provide a Node build script and npm target that copy the static assets into an `out/` directory for hosting
- configure Vercel to run the new build step so deployments expose the generated static site

## Testing
- npm run build:web
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d8eae68b2c8332b0f7c350bfd844f0