### PR TITLE
Normalize ELECTRON_START_URL overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ npm start
 
 ### Overriding the start URL
 
-During development you can point the shell at a different origin by setting the `ELECTRON_START_URL` environment variable. The value must be a full `http://`, `https://`, or `file://` URL so the app can parse and validate it. For example:
+During development you can point the shell at a different origin by setting the `ELECTRON_START_URL` environment variable. The value is trimmed before use and must resolve to a full `http://`, `https://`, or `file://` URL so the app can parse and validate it. For example:
 
 ```bash
 ELECTRON_START_URL=http://localhost:3000 npm start
 ```
 
-If the override is missing or fails validation (for example, because it is not a parseable `http(s)` or `file` URL), the shell falls back to the production BreakoutProp URL to avoid loading an unexpected destination.
+If the override is missing or fails validation (for example, because it is blank, not parseable, or uses an unexpected scheme), the shell falls back to the production BreakoutProp URL to avoid loading an unexpected destination.
 
 ## Packaging and Distribution
 

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -123,7 +123,7 @@ test(
     await flushPromises();
 
     const [createdWindow] = double.BrowserWindowStub.instances;
-    assert.deepEqual(createdWindow.loadCalls, ['http://localhost:3000']);
+    assert.deepEqual(createdWindow.loadCalls, ['http://localhost:3000/']);
 
     assert.ok(
       createdWindow.windowOpenHandler,
@@ -183,33 +183,79 @@ test(
   'bootstrap falls back to default when ELECTRON_START_URL has unsupported protocol',
   { concurrency: false },
   async () => {
+    const invalidCases = [
+      { label: 'missing protocol', value: 'localhost:3000' },
+      { label: 'javascript scheme', value: 'javascript:alert(1)' },
+      { label: 'whitespace', value: '   ' },
+      { label: 'malformed string', value: '::://broken' },
+    ];
+
+    for (const { label, value } of invalidCases) {
+      const double = createElectronDouble();
+      __setElectronForTesting(double.bindings);
+
+      const warnings = [];
+      const originalWarn = console.warn;
+      console.warn = (...args) => {
+        warnings.push(args.join(' '));
+      };
+
+      process.env.ELECTRON_START_URL = value;
+
+      try {
+        bootstrap();
+        await flushPromises();
+
+        const [createdWindow] = double.BrowserWindowStub.instances;
+        assert.deepEqual(
+          createdWindow.loadCalls,
+          ['https://app.breakoutprop.com'],
+          `expected fallback for ${label}`,
+        );
+        assert.ok(
+          warnings.some((message) => message.includes(`"${value}"`)),
+          `expected warning for ${label}`,
+        );
+      } finally {
+        console.warn = originalWarn;
+        delete process.env.ELECTRON_START_URL;
+        __resetForTesting();
+      }
+    }
+  },
+);
+
+test(
+  'bootstrap accepts file:// overrides and keeps navigation in-app',
+  { concurrency: false },
+  async () => {
     const double = createElectronDouble();
     __setElectronForTesting(double.bindings);
 
-    const originalWarn = console.warn;
-    const warnings = [];
-    console.warn = (...args) => {
-      warnings.push(args.join(' '));
+    process.env.ELECTRON_START_URL = '  file:///tmp/index.html  ';
+
+    bootstrap();
+    await flushPromises();
+
+    const [createdWindow] = double.BrowserWindowStub.instances;
+    assert.deepEqual(createdWindow.loadCalls, ['file:///tmp/index.html']);
+
+    assert.ok(createdWindow.windowOpenHandler, 'expected window open handler to be registered');
+    const allowResult = createdWindow.windowOpenHandler({
+      url: 'file:///tmp/next.html',
+    });
+    assert.deepEqual(allowResult, { action: 'allow' });
+
+    const navHandler = createdWindow.webContentsHandlers['will-navigate'];
+    const event = { prevented: false };
+    event.preventDefault = () => {
+      event.prevented = true;
     };
 
-    process.env.ELECTRON_START_URL = 'localhost:3000';
+    navHandler(event, 'file:///tmp/next.html');
+    assert.equal(event.prevented, false);
 
-    try {
-      bootstrap();
-      await flushPromises();
-
-      const [createdWindow] = double.BrowserWindowStub.instances;
-      assert.deepEqual(createdWindow.loadCalls, ['https://app.breakoutprop.com']);
-      assert.ok(
-        warnings.some((message) =>
-          message.includes('Ignoring unsupported ELECTRON_START_URL value "localhost:3000"'),
-        ),
-        'expected warning about unsupported ELECTRON_START_URL',
-      );
-    } finally {
-      console.warn = originalWarn;
-      delete process.env.ELECTRON_START_URL;
-      __resetForTesting();
-    }
+    delete process.env.ELECTRON_START_URL;
+    __resetForTesting();
   },
 );


### PR DESCRIPTION
## Summary
- trim and normalize ELECTRON_START_URL overrides, only trusting http/https/file schemes and updating allowed origins accordingly
- align navigation checks with the new validation to support file:// starts while blocking unexpected protocols
- expand bootstrap unit coverage for invalid overrides and document the behavior in the README

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d8ec5ca8788332bb74931caecb31aa