### PR TITLE
Add GitHub installer downloader script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   lint-and-test:
-
     runs-on: ubuntu-latest
     env:
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'

--- a/README.md
+++ b/README.md
@@ -54,6 +54,23 @@ npm run package
 npm run make
 ```
 
+### Downloading the latest published installer
+
+To retrieve the most up-to-date installer published on GitHub, use the bundled downloader script. The tool automatically selects the best asset for your platform and architecture, writing the installer to the current working directory by default.
+
+```bash
+# Download the newest installer for your current platform
+npm run download:installer
+
+# Override the platform/architecture or save location when needed
+node scripts/download-latest-installer.js \
+  --platform win32 \
+  --arch x64 \
+  --output ./downloads
+```
+
+Set a `GITHUB_TOKEN` (or `GH_TOKEN`) environment variable if you need to authenticate to avoid GitHub API rate limits.
+
 Refer to the Forge configuration embedded in `package.json` (`package.json → config.forge`) for maker and plugin settings. Within that JSON block you can add, remove, or adjust makers and plugins to match the installers and packaging tweaks your release process requires.
 
 ## Updating an Existing Installation

--- a/main.js
+++ b/main.js
@@ -8,20 +8,14 @@ let { app, BrowserWindow, shell, session } = electron;
 // UI pulling first-party assets plus Cloudflare's analytics beacon. Keep these
 // allow-lists in sync with that remote footprint so the nonce-based CSP stays
 // permissive only where the app genuinely needs it.
-const breakoutOrigins = [
-  'https://app.breakoutprop.com',
-  'https://*.breakoutprop.com',
-];
+const breakoutOrigins = ['https://app.breakoutprop.com', 'https://*.breakoutprop.com'];
 const cspScriptOrigins = [
   ...breakoutOrigins,
   // Cloudflare Radar beacon script used by the hosted experience.
   'https://performance.radar.cloudflare.com',
 ];
 const cspStyleOrigins = breakoutOrigins;
-const cspConnectOrigins = [
-  ...breakoutOrigins,
-  'wss://*.breakoutprop.com',
-];
+const cspConnectOrigins = [...breakoutOrigins, 'wss://*.breakoutprop.com'];
 
 function buildContentSecurityPolicy() {
   const nonce = crypto.randomBytes(16).toString('base64');
@@ -63,7 +57,6 @@ const allowedProtocols = new Set(['https:']);
 
 let startUrl = defaultAllowedOrigin;
 
-
 function resetAllowedOrigins() {
   allowedOrigins = new Set([defaultAllowedOrigin]);
 }
@@ -76,7 +69,6 @@ function isOriginAllowed(url) {
     return false;
   }
 }
-
 
 function openExternalIfSafe(targetUrl, openExternal = shell.openExternal) {
   let parsed;
@@ -167,7 +159,6 @@ function bootstrap() {
       try {
         const parsedStart = new URL(startUrl);
         allowedOrigins.add(parsedStart.origin);
-
       } catch {
         startUrl = defaultAllowedOrigin;
       }

--- a/package.json
+++ b/package.json
@@ -13,13 +13,13 @@
     "test:unit": "node --test test",
     "test": "npm run lint && npm run format && npm run test:unit && npm run test:integration",
     "test:integration": "node scripts/run-playwright.js",
-
     "start": "electron-forge start",
     "prepackage": "npm run generate:icons",
     "package": "electron-forge package",
     "premake": "npm run generate:icons",
     "make": "electron-forge make",
-    "build:web": "node scripts/build-web.js"
+    "build:web": "node scripts/build-web.js",
+    "download:installer": "node scripts/download-latest-installer.js"
   },
   "keywords": [],
   "devDependencies": {

--- a/scripts/download-latest-installer.js
+++ b/scripts/download-latest-installer.js
@@ -1,0 +1,336 @@
+#!/usr/bin/env node
+const fs = require('node:fs/promises');
+const path = require('node:path');
+
+const DEFAULT_REPO = 'kdkiss/breakoutpropterminal';
+const DEFAULT_OUTPUT_DIR = process.cwd();
+
+const ARCH_ALIASES = {
+  x64: ['x64', 'x86_64', 'amd64'],
+  arm64: ['arm64', 'aarch64'],
+  ia32: ['ia32', 'x86', 'x32'],
+};
+
+const PLATFORM_PATTERNS = {
+  win32: [/\.exe$/i, /\.msi$/i, /\.zip$/i],
+  darwin: [/\.dmg$/i, /\.pkg$/i, /\.zip$/i],
+  linux: [/\.AppImage$/i, /\.deb$/i, /\.rpm$/i, /\.tar\.gz$/i, /\.zip$/i],
+  default: [/\.zip$/i, /\.tar\.gz$/i],
+};
+
+function buildHeaders(token) {
+  const headers = {
+    'User-Agent': 'breakoutprop-downloader',
+    Accept: 'application/vnd.github+json',
+  };
+
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  return headers;
+}
+
+function getArchAliases(arch) {
+  const aliases = ARCH_ALIASES[arch];
+  if (!aliases) {
+    return [];
+  }
+
+  return aliases.map((alias) => alias.toLowerCase());
+}
+
+function getOtherArchAliases(arch) {
+  const others = [];
+  for (const [key, aliases] of Object.entries(ARCH_ALIASES)) {
+    if (key === arch) {
+      continue;
+    }
+
+    for (const alias of aliases) {
+      others.push(alias.toLowerCase());
+    }
+  }
+
+  return others;
+}
+
+function splitByArchPreference(assets, arch) {
+  const archAliases = getArchAliases(arch);
+
+  if (archAliases.length === 0) {
+    return { preferred: assets.slice(), fallback: [] };
+  }
+
+  const otherAliases = getOtherArchAliases(arch);
+  const preferred = [];
+  const fallback = [];
+
+  for (const asset of assets) {
+    const haystack =
+      `${asset.name || ''} ${(asset.browser_download_url || '').toLowerCase()}`.toLowerCase();
+    if (archAliases.some((alias) => haystack.includes(alias))) {
+      preferred.push(asset);
+      continue;
+    }
+
+    if (otherAliases.some((alias) => haystack.includes(alias))) {
+      continue;
+    }
+
+    fallback.push(asset);
+  }
+
+  return { preferred, fallback };
+}
+
+function selectAssetFromRelease(release, options = {}) {
+  if (!release || !Array.isArray(release.assets)) {
+    throw new Error('Release data did not include assets.');
+  }
+
+  const assets = release.assets;
+
+  if (assets.length === 0) {
+    throw new Error('Latest release does not contain any downloadable assets.');
+  }
+
+  const { platform = process.platform, arch = process.arch, assetPattern } = options;
+
+  const patterns = [];
+
+  if (assetPattern) {
+    const customPattern =
+      assetPattern instanceof RegExp ? assetPattern : new RegExp(assetPattern, 'i');
+    patterns.push(customPattern);
+  }
+
+  const platformPatterns = PLATFORM_PATTERNS[platform] || [];
+  patterns.push(...platformPatterns, ...PLATFORM_PATTERNS.default);
+
+  let fallbackMatch = null;
+
+  for (const pattern of patterns) {
+    const matchingAssets = assets.filter((asset) => {
+      const name = asset.name || '';
+      const url = asset.browser_download_url || '';
+      return pattern.test(name) || pattern.test(url);
+    });
+
+    if (matchingAssets.length === 0) {
+      continue;
+    }
+
+    const { preferred, fallback } = splitByArchPreference(matchingAssets, arch);
+
+    if (preferred.length > 0) {
+      return preferred[0];
+    }
+
+    if (!fallbackMatch && fallback.length > 0) {
+      fallbackMatch = fallback[0];
+    }
+  }
+
+  return fallbackMatch || assets[0];
+}
+
+async function fetchLatestRelease(repo, fetchImpl = globalThis.fetch, token) {
+  if (typeof fetchImpl !== 'function') {
+    throw new TypeError('A fetch implementation must be provided.');
+  }
+
+  const response = await fetchImpl(`https://api.github.com/repos/${repo}/releases/latest`, {
+    headers: buildHeaders(token),
+  });
+
+  if (!response || !response.ok) {
+    const status = response ? `${response.status}` : 'unknown';
+    throw new Error(`Failed to fetch latest release metadata (status: ${status}).`);
+  }
+
+  return response.json();
+}
+
+function resolveFileName(asset, url) {
+  if (asset.name) {
+    return asset.name;
+  }
+
+  try {
+    const parsed = new URL(url);
+    return path.basename(parsed.pathname);
+  } catch {
+    return 'download';
+  }
+}
+
+async function downloadAsset(asset, outputDir, fetchImpl = globalThis.fetch, token) {
+  if (!asset || !asset.browser_download_url) {
+    throw new Error('Asset is missing a browser_download_url.');
+  }
+
+  const response = await fetchImpl(asset.browser_download_url, {
+    headers: buildHeaders(token),
+  });
+
+  if (!response || !response.ok) {
+    const status = response ? `${response.status}` : 'unknown';
+    throw new Error(`Failed to download asset (status: ${status}).`);
+  }
+
+  const arrayBuffer = await response.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+  const fileName = resolveFileName(asset, asset.browser_download_url);
+  await fs.mkdir(outputDir, { recursive: true });
+  const destination = path.join(outputDir, fileName);
+  await fs.writeFile(destination, buffer);
+  return destination;
+}
+
+async function downloadLatestInstaller(options = {}) {
+  const {
+    repo = DEFAULT_REPO,
+    platform = process.platform,
+    arch = process.arch,
+    outputDir = DEFAULT_OUTPUT_DIR,
+    assetPattern,
+    fetchImpl = globalThis.fetch,
+    token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN,
+  } = options;
+
+  const release = await fetchLatestRelease(repo, fetchImpl, token);
+  const asset = selectAssetFromRelease(release, { platform, arch, assetPattern });
+  const filePath = await downloadAsset(asset, outputDir, fetchImpl, token);
+
+  return {
+    filePath,
+    release,
+    asset,
+  };
+}
+
+function formatSuccessMessage(result) {
+  const { filePath, release, asset } = result;
+  const lines = [`Downloaded ${asset.name || 'installer'} to ${filePath}.`];
+
+  if (release && release.tag_name) {
+    lines.push(`Release: ${release.tag_name}`);
+  }
+
+  return lines.join('\n');
+}
+
+function printUsage() {
+  const usage =
+    `Usage: node scripts/download-latest-installer.js [options]\n\n` +
+    `Options:\n` +
+    `  --platform <platform>       Platform to download for (default: current platform)\n` +
+    `  --arch <arch>               Architecture to download for (default: current arch)\n` +
+    `  --repo <owner/repo>         Repository to query (default: ${DEFAULT_REPO})\n` +
+    `  --output <dir>              Directory to save the installer (default: current directory)\n` +
+    `  --asset-pattern <pattern>   Regular expression to match asset names\n` +
+    `  --token <token>             GitHub token (falls back to GITHUB_TOKEN/GH_TOKEN env vars)\n` +
+    `  -h, --help                  Show this help message\n`;
+
+  console.log(usage);
+}
+
+function parseArgs(argv) {
+  const options = {
+    outputDir: DEFAULT_OUTPUT_DIR,
+  };
+
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+
+    if (arg === '--help' || arg === '-h') {
+      return { help: true };
+    }
+
+    if (!arg.startsWith('--')) {
+      options.outputDir = path.resolve(process.cwd(), arg);
+      continue;
+    }
+
+    const [flag, valueFromEquals] = arg.split('=');
+    let value = valueFromEquals;
+
+    if (value == null) {
+      value = argv[i + 1];
+      i += 1;
+    }
+
+    if (value == null || value.startsWith('--')) {
+      throw new Error(`Option ${flag} requires a value.`);
+    }
+
+    switch (flag) {
+      case '--platform':
+        options.platform = value;
+        break;
+      case '--arch':
+        options.arch = value;
+        break;
+      case '--repo':
+        options.repo = value;
+        break;
+      case '--output':
+        options.outputDir = path.resolve(process.cwd(), value);
+        break;
+      case '--asset-pattern':
+        options.assetPattern = value;
+        break;
+      case '--token':
+        options.token = value;
+        break;
+      default:
+        throw new Error(`Unknown option: ${flag}`);
+    }
+  }
+
+  return options;
+}
+
+async function runCli() {
+  let options;
+
+  try {
+    options = parseArgs(process.argv);
+  } catch (error) {
+    console.error(error.message);
+    printUsage();
+    process.exitCode = 1;
+    return;
+  }
+
+  if (options.help) {
+    printUsage();
+    return;
+  }
+
+  try {
+    const result = await downloadLatestInstaller(options);
+    console.log(formatSuccessMessage(result));
+  } catch (error) {
+    console.error(`Failed to download installer: ${error.message}`);
+    process.exitCode = 1;
+  }
+}
+
+if (require.main === module) {
+  runCli();
+}
+
+module.exports = {
+  ARCH_ALIASES,
+  PLATFORM_PATTERNS,
+  buildHeaders,
+  selectAssetFromRelease,
+  downloadLatestInstaller,
+  fetchLatestRelease,
+  downloadAsset,
+  parseArgs,
+  formatSuccessMessage,
+  splitByArchPreference,
+};

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -97,10 +97,7 @@ test(
     await flushPromises();
 
     assert.equal(double.onHeadersReceivedHandlers.length, 1);
-    assert.strictEqual(
-      double.onHeadersReceivedHandlers[0],
-      ensureContentSecurityPolicy,
-    );
+    assert.strictEqual(double.onHeadersReceivedHandlers[0], ensureContentSecurityPolicy);
 
     assert.equal(double.BrowserWindowStub.instances.length, 1);
     const [createdWindow] = double.BrowserWindowStub.instances;
@@ -125,10 +122,7 @@ test(
     const [createdWindow] = double.BrowserWindowStub.instances;
     assert.deepEqual(createdWindow.loadCalls, ['http://localhost:3000']);
 
-    assert.ok(
-      createdWindow.windowOpenHandler,
-      'expected window open handler to be registered',
-    );
+    assert.ok(createdWindow.windowOpenHandler, 'expected window open handler to be registered');
 
     const navHandler = createdWindow.webContentsHandlers['will-navigate'];
     assert.ok(navHandler, 'expected will-navigate handler to be registered');
@@ -172,7 +166,6 @@ test(
       'https://example.com/out',
       'https://example.com/elsewhere',
     ]);
-
 
     delete process.env.ELECTRON_START_URL;
     __resetForTesting();

--- a/test/downloadLatestInstaller.test.js
+++ b/test/downloadLatestInstaller.test.js
@@ -1,0 +1,117 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  selectAssetFromRelease,
+  splitByArchPreference,
+  downloadLatestInstaller,
+} = require('../scripts/download-latest-installer.js');
+
+function createRelease(assets) {
+  return {
+    tag_name: 'v1.2.3',
+    assets,
+  };
+}
+
+test('selectAssetFromRelease prefers platform-specific installer', () => {
+  const release = createRelease([
+    {
+      name: 'BreakoutProp-Terminal-Setup-x64.exe',
+      browser_download_url: 'https://example.com/win-x64.exe',
+    },
+    {
+      name: 'BreakoutProp-Terminal-Setup-arm64.exe',
+      browser_download_url: 'https://example.com/win-arm64.exe',
+    },
+    {
+      name: 'BreakoutProp-Terminal.dmg',
+      browser_download_url: 'https://example.com/mac.dmg',
+    },
+  ]);
+
+  const asset = selectAssetFromRelease(release, { platform: 'win32', arch: 'x64' });
+  assert.equal(asset.browser_download_url, 'https://example.com/win-x64.exe');
+});
+
+test('selectAssetFromRelease falls back to neutral asset when arch not tagged', () => {
+  const release = createRelease([
+    {
+      name: 'BreakoutProp-Terminal-Setup.exe',
+      browser_download_url: 'https://example.com/win.exe',
+    },
+    {
+      name: 'BreakoutProp-Terminal-arm64.dmg',
+      browser_download_url: 'https://example.com/mac-arm64.dmg',
+    },
+  ]);
+
+  const asset = selectAssetFromRelease(release, { platform: 'win32', arch: 'x64' });
+  assert.equal(asset.browser_download_url, 'https://example.com/win.exe');
+});
+
+test('splitByArchPreference filters out conflicting architectures', () => {
+  const assets = [{ name: 'app-x64.exe' }, { name: 'app-arm64.exe' }, { name: 'app.exe' }];
+
+  const { preferred, fallback } = splitByArchPreference(assets, 'x64');
+  assert.deepEqual(
+    preferred.map((asset) => asset.name),
+    ['app-x64.exe'],
+  );
+  assert.deepEqual(
+    fallback.map((asset) => asset.name),
+    ['app.exe'],
+  );
+});
+
+test('downloadLatestInstaller writes installer to disk', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'installer-test-'));
+  const release = createRelease([
+    {
+      name: 'BreakoutProp-Terminal-Setup.exe',
+      browser_download_url: 'https://example.com/win.exe',
+    },
+  ]);
+
+  const downloaded = [];
+
+  const fakeFetch = async (url) => {
+    if (url.includes('/releases/latest')) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => release,
+      };
+    }
+
+    if (url === 'https://example.com/win.exe') {
+      downloaded.push(url);
+      const payload = Buffer.from('installer');
+      return {
+        ok: true,
+        status: 200,
+        arrayBuffer: async () =>
+          payload.buffer.slice(payload.byteOffset, payload.byteOffset + payload.byteLength),
+      };
+    }
+
+    throw new Error(`Unexpected URL: ${url}`);
+  };
+
+  const result = await downloadLatestInstaller({
+    repo: 'example/repo',
+    platform: 'win32',
+    arch: 'x64',
+    outputDir: tmpDir,
+    fetchImpl: fakeFetch,
+  });
+
+  assert.equal(downloaded.length, 1);
+  const outputFile = path.join(tmpDir, 'BreakoutProp-Terminal-Setup.exe');
+  const contents = await fs.readFile(outputFile, 'utf8');
+  assert.equal(contents, 'installer');
+  assert.equal(result.filePath, outputFile);
+});

--- a/test/ensureContentSecurityPolicy.test.js
+++ b/test/ensureContentSecurityPolicy.test.js
@@ -14,9 +14,7 @@ function captureResult(fn) {
 test('ensureContentSecurityPolicy injects a nonce-based header when missing', async () => {
   const details = { responseHeaders: {} };
 
-  const result = await captureResult((callback) =>
-    ensureContentSecurityPolicy(details, callback),
-  );
+  const result = await captureResult((callback) => ensureContentSecurityPolicy(details, callback));
 
   assert.ok(result.responseHeaders['Content-Security-Policy']);
   const [policy] = result.responseHeaders['Content-Security-Policy'];
@@ -33,9 +31,7 @@ test('ensureContentSecurityPolicy preserves existing headers', async () => {
 
   const details = { responseHeaders: originalHeaders };
 
-  const result = await captureResult((callback) =>
-    ensureContentSecurityPolicy(details, callback),
-  );
+  const result = await captureResult((callback) => ensureContentSecurityPolicy(details, callback));
 
   assert.strictEqual(result.responseHeaders, originalHeaders);
   assert.deepEqual(result.responseHeaders['content-security-policy'], ["default-src 'self'"]);

--- a/test/openExternalIfSafe.test.js
+++ b/test/openExternalIfSafe.test.js
@@ -11,10 +11,7 @@ test('allows https URLs to open externally', () => {
     openedUrl = url;
   };
 
-  const httpsResult = openExternalIfSafe(
-    'https://example.com/path',
-    openExternalStub,
-  );
+  const httpsResult = openExternalIfSafe('https://example.com/path', openExternalStub);
 
   assert.equal(httpsResult, true);
   assert.equal(openedUrl, 'https://example.com/path');
@@ -31,7 +28,6 @@ test('allows https URLs to open externally', () => {
 
   assert.equal(httpResult, false);
   assert.equal(openedUrl, null);
-
 });
 
 test('rejects URLs with disallowed protocols', () => {

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -97,9 +97,7 @@ test.describe('Breakout Prop Electron app', () => {
 
       const breakoutPopup = await breakoutPopupPromise;
       await breakoutPopup.waitForLoadState('domcontentloaded').catch(() => {});
-      expect(await breakoutPopup.url()).toBe(
-        'https://app.breakoutprop.com/dashboard',
-      );
+      expect(await breakoutPopup.url()).toBe('https://app.breakoutprop.com/dashboard');
       await breakoutPopup.close();
     } finally {
       if (electronApp) {

--- a/web/index.html
+++ b/web/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -18,8 +18,8 @@
       <div class="hero__content">
         <h1>BreakoutProp Terminal</h1>
         <p>
-          Launch the BreakoutProp trading experience in a hardened desktop
-          shell, purpose-built for focused execution and safe navigation.
+          Launch the BreakoutProp trading experience in a hardened desktop shell, purpose-built for
+          focused execution and safe navigation.
         </p>
         <div class="hero__actions">
           <a class="btn btn--primary" href="https://github.com/kdkiss/breakoutpropterminal/releases"
@@ -40,24 +40,22 @@
           <article class="card">
             <h3>Secure defaults</h3>
             <p>
-              We isolate renderer processes, apply restrictive navigation
-              policies, and inject a modern content security policy before
-              remote pages load.
+              We isolate renderer processes, apply restrictive navigation policies, and inject a
+              modern content security policy before remote pages load.
             </p>
           </article>
           <article class="card">
             <h3>First-party experience</h3>
             <p>
-              The terminal wraps the official BreakoutProp interface, so users
-              authenticate and trade against the same endpoints they already
-              trust in the browser.
+              The terminal wraps the official BreakoutProp interface, so users authenticate and
+              trade against the same endpoints they already trust in the browser.
             </p>
           </article>
           <article class="card">
             <h3>Cross-platform delivery</h3>
             <p>
-              Build installers with Electron Forge for Windows, macOS, or Linux
-              without rewriting your web application.
+              Build installers with Electron Forge for Windows, macOS, or Linux without rewriting
+              your web application.
             </p>
           </article>
         </div>
@@ -67,11 +65,14 @@
         <div class="callout">
           <h2>Prefer the browser?</h2>
           <p>
-            You can still access the BreakoutProp terminal online. Launch the
-            hosted experience directly in your browser if you do not need the
-            native shell.
+            You can still access the BreakoutProp terminal online. Launch the hosted experience
+            directly in your browser if you do not need the native shell.
           </p>
-          <a class="btn btn--ghost" href="https://app.breakoutprop.com" target="_blank" rel="noopener"
+          <a
+            class="btn btn--ghost"
+            href="https://app.breakoutprop.com"
+            target="_blank"
+            rel="noopener"
             >Open web terminal</a
           >
         </div>

--- a/web/styles.css
+++ b/web/styles.css
@@ -7,7 +7,12 @@
   --text: #f5f7ff;
   --text-muted: #c0c6e7;
   --border: rgba(255, 255, 255, 0.08);
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+  font-family:
+    'Inter',
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
     sans-serif;
 }
 
@@ -17,8 +22,8 @@
 
 body {
   margin: 0;
-  background: radial-gradient(circle at top right, rgba(92, 124, 250, 0.25), transparent 45%),
-    var(--bg);
+  background:
+    radial-gradient(circle at top right, rgba(92, 124, 250, 0.25), transparent 45%), var(--bg);
   color: var(--text);
   min-height: 100vh;
   display: flex;
@@ -59,7 +64,10 @@ body {
   text-decoration: none;
   color: var(--text);
   background: rgba(255, 255, 255, 0.04);
-  transition: transform 180ms ease, box-shadow 180ms ease, background 180ms ease,
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    background 180ms ease,
     border-color 180ms ease;
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- add a `download-latest-installer` script that locates the newest GitHub release asset for the current platform and downloads it with optional CLI overrides
- expose the downloader via an npm script, document usage in the README, and normalize repository formatting with Prettier so linting succeeds
- cover asset selection heuristics and download flow with new unit tests

## Testing
- npm test *(fails: Playwright electron launch requires a display in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8ed6ad2208332b0be671ed53c35b3