### PR TITLE
Add dynamic latest release section

### DIFF
--- a/main.js
+++ b/main.js
@@ -173,6 +173,8 @@ function bootstrap() {
     }
   }
 
+  startUrl = normalizedStartUrl;
+
   if (typeof startUrl === 'string') {
     const isHttp = startUrl.startsWith('http://') || startUrl.startsWith('https://');
 
@@ -185,7 +187,6 @@ function bootstrap() {
       }
     }
   }
-
 
   app.whenReady().then(() => {
     if (session.defaultSession) {

--- a/web/index.html
+++ b/web/index.html
@@ -34,6 +34,12 @@
     </header>
 
     <main>
+      <section class="section section--release">
+        <div class="release-card" data-release-card>
+          <p class="release-card__status">Fetching the latest release…</p>
+        </div>
+      </section>
+
       <section id="features" class="section section--features">
         <h2>Why ship a dedicated terminal?</h2>
         <div class="grid">

--- a/web/main.js
+++ b/web/main.js
@@ -8,6 +8,192 @@ installButtons.forEach((button) => {
   });
 });
 
+const RELEASES_API_URL = 'https://api.github.com/repos/kdkiss/breakoutpropterminal/releases/latest';
+
+function formatDate(value) {
+  if (!value) {
+    return null;
+  }
+
+  const date = value instanceof Date ? value : new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return date.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+function formatFileSize(bytes) {
+  if (!Number.isFinite(bytes) || bytes < 0) {
+    return null;
+  }
+
+  if (bytes === 0) {
+    return '0 B';
+  }
+
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const exponent = Math.min(units.length - 1, Math.floor(Math.log(bytes) / Math.log(1024)));
+  const value = bytes / Math.pow(1024, exponent);
+  return `${value.toFixed(value >= 10 || exponent === 0 ? 0 : 1)} ${units[exponent]}`;
+}
+
+function renderReleaseError(container) {
+  container.innerHTML = '';
+
+  const message = document.createElement('p');
+  message.className = 'release-card__status release-card__status--error';
+  message.textContent = 'Unable to load release details right now.';
+
+  const fallback = document.createElement('p');
+  fallback.className = 'release-card__status';
+  fallback.append('Visit ');
+
+  const fallbackLink = document.createElement('a');
+  fallbackLink.href = 'https://github.com/kdkiss/breakoutpropterminal/releases';
+  fallbackLink.target = '_blank';
+  fallbackLink.rel = 'noopener';
+  fallbackLink.textContent = 'GitHub releases';
+
+  fallback.append(fallbackLink, ' to download installers.');
+
+  container.append(message, fallback);
+}
+
+function renderRelease(container, release) {
+  container.innerHTML = '';
+
+  const heading = document.createElement('h2');
+  heading.textContent = release.name || release.tag_name || 'Latest release';
+  container.appendChild(heading);
+
+  const meta = document.createElement('p');
+  meta.className = 'release-card__meta';
+
+  const publishedDate = formatDate(release.published_at || release.created_at);
+  if (publishedDate) {
+    meta.textContent = `Published ${publishedDate}`;
+  } else {
+    meta.textContent = 'Latest release metadata from GitHub.';
+  }
+
+  container.appendChild(meta);
+
+  const assets = Array.isArray(release.assets)
+    ? release.assets.filter((asset) => Boolean(asset.browser_download_url))
+    : [];
+
+  if (assets.length === 0) {
+    const status = document.createElement('p');
+    status.className = 'release-card__status';
+    status.append('No downloadable assets were found. Visit ');
+
+    const link = document.createElement('a');
+    link.href =
+      release.html_url || 'https://github.com/kdkiss/breakoutpropterminal/releases/latest';
+    link.target = '_blank';
+    link.rel = 'noopener';
+    link.textContent = 'GitHub';
+
+    status.append(link, ' for more details.');
+    container.appendChild(status);
+    return;
+  }
+
+  const list = document.createElement('ul');
+  list.className = 'release-card__assets';
+
+  for (const asset of assets) {
+    const item = document.createElement('li');
+    item.className = 'release-card__asset';
+
+    const link = document.createElement('a');
+    link.href = asset.browser_download_url;
+    link.textContent = asset.name || 'Download asset';
+    link.target = '_blank';
+    link.rel = 'noopener';
+
+    const metaLine = document.createElement('span');
+    metaLine.className = 'release-card__asset-meta';
+
+    const details = [];
+    const size = formatFileSize(asset.size);
+    if (size) {
+      details.push(size);
+    }
+
+    if (typeof asset.download_count === 'number') {
+      details.push(`${asset.download_count.toLocaleString()} downloads`);
+    }
+
+    const updatedDate = formatDate(asset.updated_at);
+    if (updatedDate) {
+      details.push(`Updated ${updatedDate}`);
+    }
+
+    metaLine.textContent = details.join(' • ');
+
+    item.append(link);
+    if (details.length > 0) {
+      item.appendChild(metaLine);
+    }
+
+    list.appendChild(item);
+  }
+
+  container.appendChild(list);
+
+  const releaseLink = document.createElement('p');
+  releaseLink.className = 'release-card__status';
+  releaseLink.append('View full notes on ');
+
+  const releaseAnchor = document.createElement('a');
+  releaseAnchor.href =
+    release.html_url || 'https://github.com/kdkiss/breakoutpropterminal/releases/latest';
+  releaseAnchor.target = '_blank';
+  releaseAnchor.rel = 'noopener';
+  releaseAnchor.textContent = 'GitHub';
+
+  releaseLink.append(releaseAnchor, '.');
+  container.appendChild(releaseLink);
+}
+
+async function hydrateLatestRelease() {
+  const container = document.querySelector('[data-release-card]');
+
+  if (!container) {
+    return;
+  }
+
+  const status = container.querySelector('.release-card__status');
+  if (status) {
+    status.textContent = 'Fetching the latest release…';
+  }
+
+  try {
+    const response = await fetch(RELEASES_API_URL, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Request failed with status ${response.status}`);
+    }
+
+    const release = await response.json();
+    renderRelease(container, release);
+  } catch (error) {
+    console.error('Failed to load latest release metadata', error);
+    renderReleaseError(container);
+  }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const yearSpan = document.createElement('span');
   yearSpan.textContent = ` © ${new Date().getFullYear()}`;
@@ -16,4 +202,6 @@ document.addEventListener('DOMContentLoaded', () => {
   if (footer) {
     footer.appendChild(yearSpan);
   }
+
+  hydrateLatestRelease();
 });

--- a/web/styles.css
+++ b/web/styles.css
@@ -109,6 +109,73 @@ body {
   padding: 3rem clamp(1.5rem, 6vw, 5rem);
 }
 
+.section--release {
+  display: flex;
+  justify-content: center;
+  padding-bottom: 1.5rem;
+}
+
+.release-card {
+  width: min(720px, 100%);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  padding: clamp(1.75rem, 4vw, 2.5rem);
+  box-shadow: 0 18px 38px rgba(6, 6, 14, 0.38);
+}
+
+.release-card h2 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.6rem, 3vw, 2rem);
+}
+
+.release-card__meta {
+  margin: 0 0 1.5rem;
+  color: var(--text-muted);
+}
+
+.release-card__status {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.release-card__status--error {
+  color: #ffb3c1;
+}
+
+.release-card__assets {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.release-card__asset {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 16px;
+  padding: 0.85rem 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.release-card__asset a {
+  color: var(--text);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.release-card__asset a:hover {
+  text-decoration: underline;
+}
+
+.release-card__asset-meta {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
 .section--features h2 {
   text-align: center;
   margin-bottom: 2.5rem;


### PR DESCRIPTION
## Summary
- surface the latest GitHub release on the marketing page with live data
- style the new release card and asset list to match the existing hero aesthetic
- ensure the Electron bootstrap routine actually uses the normalized start URL value

## Testing
- npm test *(fails: Playwright Electron launch requires a display in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8efbe6ee48332ba7662827a5cf585