### PR TITLE
Restore sanitized start URL override to bootstrap

### DIFF
--- a/main.js
+++ b/main.js
@@ -153,7 +153,6 @@ function bootstrap() {
         // the shell into executing arbitrary protocols inside Electron.
         if (parsedStart.protocol === 'http:' || parsedStart.protocol === 'https:') {
           normalizedStartUrl = parsedStart.toString();
-          allowedOrigins.add(parsedStart.origin);
         } else if (parsedStart.protocol === 'file:') {
           normalizedStartUrl = parsedStart.toString();
         } else {
@@ -173,6 +172,8 @@ function bootstrap() {
     }
   }
 
+  startUrl = normalizedStartUrl;
+
   if (typeof startUrl === 'string') {
     const isHttp = startUrl.startsWith('http://') || startUrl.startsWith('https://');
 
@@ -185,7 +186,6 @@ function bootstrap() {
       }
     }
   }
-
 
   app.whenReady().then(() => {
     if (session.defaultSession) {


### PR DESCRIPTION
## Summary
- assign the validated ELECTRON_START_URL override back to the module-level startUrl before creating windows
- update allowed-origins tracking to rely on the sanitized start URL when adding HTTP(S) origins

## Testing
- npm test *(fails: Playwright Electron process failed to launch in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8f106a1988332a48179f60f0a5470