### PR TITLE
Refine navigation guards and block disallowed popups

### DIFF
--- a/main.js
+++ b/main.js
@@ -4,6 +4,14 @@ const electron = require('electron');
 
 let { app, BrowserWindow, shell, session } = electron;
 
+const lockedDownWebPreferences = {
+  nodeIntegration: false,
+  contextIsolation: true,
+  sandbox: true,
+  enableRemoteModule: false,
+  preload: path.join(__dirname, 'preload.js'),
+};
+
 // Network captures of https://app.breakoutprop.com/ (via Playwright) show the
 // UI pulling first-party assets plus Cloudflare's analytics beacon. Keep these
 // allow-lists in sync with that remote footprint so the nonce-based CSP stays
@@ -102,37 +110,48 @@ function openExternalIfSafe(targetUrl, openExternal = shell.openExternal) {
   return true;
 }
 
-function createWindow() {
-  const win = new BrowserWindow({
-    width: 1280,
-    height: 800,
-    webPreferences: {
-      nodeIntegration: false,
-      contextIsolation: true,
-      sandbox: true,
-      preload: path.join(__dirname, 'preload.js'),
-      enableRemoteModule: false,
-    },
-  });
+function applyNavigationGuards(contents) {
+  if (!contents) {
+    return;
+  }
 
-  win.loadURL(startUrl);
-
-  win.webContents.setWindowOpenHandler(({ url }) => {
+  contents.setWindowOpenHandler(({ url }) => {
     if (isOriginAllowed(url)) {
-      return { action: 'allow' };
+      return {
+        action: 'allow',
+        overrideBrowserWindowOptions: {
+          webPreferences: { ...lockedDownWebPreferences },
+        },
+      };
     }
 
     openExternalIfSafe(url);
     return { action: 'deny' };
   });
 
-  win.webContents.on('will-navigate', (event, url) => {
+  contents.on('will-navigate', (event, url) => {
     if (isOriginAllowed(url)) {
       return;
     }
 
     event.preventDefault();
     openExternalIfSafe(url);
+  });
+}
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 1280,
+    height: 800,
+    webPreferences: { ...lockedDownWebPreferences },
+  });
+
+  win.loadURL(startUrl);
+
+  applyNavigationGuards(win.webContents);
+
+  win.webContents.on('did-create-window', (childWindow) => {
+    applyNavigationGuards(childWindow.webContents);
   });
 }
 
@@ -172,6 +191,8 @@ function bootstrap() {
       );
     }
   }
+
+  startUrl = normalizedStartUrl;
 
   if (typeof startUrl === 'string') {
     const isHttp = startUrl.startsWith('http://') || startUrl.startsWith('https://');

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -90,15 +90,15 @@ test.describe('Breakout Prop Electron app', () => {
       await popup.waitForLoadState('load');
       expect(await popup.url()).toBe(`${startUrl}child`);
 
-      const breakoutPopupPromise = electronApp.waitForEvent('window');
+      const disallowedPopupPromise = electronApp
+        .waitForEvent('window', { timeout: 2000 })
+        .catch(() => null);
       await mainWindow.evaluate(() => {
-        window.open('https://app.breakoutprop.com/dashboard', '_blank');
+        window.open('https://example.com/', '_blank');
       });
 
-      const breakoutPopup = await breakoutPopupPromise;
-      await breakoutPopup.waitForLoadState('domcontentloaded').catch(() => {});
-      expect(await breakoutPopup.url()).toBe('https://app.breakoutprop.com/dashboard');
-      await breakoutPopup.close();
+      const disallowedPopup = await disallowedPopupPromise;
+      expect(disallowedPopup).toBeNull();
     } finally {
       if (electronApp) {
         await electronApp.close();


### PR DESCRIPTION
## Summary
- factor the navigation guard wiring into a reusable helper and apply it to child windows
- ensure popup windows inherit locked-down webPreferences when navigation is allowed
- extend unit and smoke tests to cover guarded child windows and blocked disallowed popups

## Testing
- npm run test:unit
- npm run test:integration *(fails: Process failed to launch in headless container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8f089ee8c83328b17335612ddb6dd